### PR TITLE
Validation before save.

### DIFF
--- a/integral-test.asd
+++ b/integral-test.asd
@@ -33,6 +33,7 @@
                  (:test-file "migration/sqlite3")
                  (:test-file "migration/mysql")
                  (:test-file "migration/postgres")
+                 (:test-file "validation")
                  (:test-file "integral"))))
 
   :defsystem-depends-on (:prove-asdf)

--- a/integral.asd
+++ b/integral.asd
@@ -29,7 +29,8 @@
                :trivial-types)
   :components ((:module "src"
                 :components
-                ((:file "integral" :depends-on ("connection" "table" "database" "migration" "type" "error" "variable"))
+                ((:file "integral" :depends-on ("connection" "table" "validation" "database" "migration" "type" "error" "variable"))
+                 (:file "validation" :depends-on ("table"))
                  (:file "table" :depends-on ("connection" "column" "database" "variable" "util"))
                  (:file "column" :depends-on ("connection" "type"))
                  (:file "connection" :depends-on ("connection-drivers" "error"))

--- a/src/table.lisp
+++ b/src/table.lisp
@@ -121,6 +121,9 @@ If you want to use another class, specify it as a superclass in the usual way.")
    (table-name :type (proper-list 'string)
                :initarg :table-name
                :initform nil)
+   (validations :type list
+                :initform nil
+                :initarg :validations)
    (generate-slots :type (proper-list 'boolean)
                    :initarg :generate-slots
                    :initform nil)
@@ -386,7 +389,6 @@ If you want to use another class, specify it as a superclass in the usual way.")
   (:method ((class <dao-table-class>))
     (when (initializedp class)
       (return-from initialize-dao-table-class))
-
     (let ((db-columns (retrieve-table-column-definitions-by-name
                        (get-connection)
                        (table-name class)))

--- a/src/validation.lisp
+++ b/src/validation.lisp
@@ -1,0 +1,113 @@
+(in-package :cl-user)
+(defpackage integral.validation
+  (:use :cl 
+        :alexandria
+        :sxql)
+  (:import-from :integral.table
+                :table-name
+                :<dao-table-class>
+                :<dao-class>)
+  (:import-from :integral.connection
+                :*db*
+                :make-connection
+                :get-connection
+                :connect-toplevel
+                :disconnect-toplevel
+                :last-insert-id
+                :database-type
+                :with-quote-char)
+  (:import-from :dbi
+                :prepare
+                :execute
+                :fetch))
+
+(in-package integral.validation)
+
+(cl-syntax:use-syntax :annot)
+
+@export
+(defgeneric validate-presence-of (object slot-name)
+  (:method ((object <dao-class>) slot-name)
+    (and (slot-boundp object slot-name)
+     (not (null (slot-value object slot-name))))))
+
+@export
+(defgeneric validate-length-of (object slot-name &key min max is)
+  (:method ((object <dao-class>) slot-name &key (min 0) max is)
+    (if (slot-boundp object slot-name)
+        (let ((val (slot-value object slot-name)))
+          (cond (is (= is (length val)))
+                (max
+                 (<= min (length val) max))
+                (<= min (length val))))
+        t)))
+
+@export
+(defgeneric validate-format-of (object slot-name format)
+  (:method ((object <dao-class>) slot-name format)
+    (if (slot-boundp object slot-name)
+        (let ((val (slot-value object slot-name)))
+          (cl-ppcre:all-matches format val))
+        t)))
+
+(defun generate-validation-function (validation-entry)
+  (if (listp validation-entry)
+      (let ((tag (car validation-entry))
+            (args (cdr validation-entry)))
+        (ecase tag
+          (:presence
+           (let ((slot-name (car args)))
+             (if (and slot-name (symbolp slot-name))
+                 (lambda (obj)
+                   (validate-presence-of obj slot-name))
+                 (error "Malformed slot-name: ~A" slot-name))))
+          (:length
+           (let ((slot-name (car args))
+                 (min (getf (cdr args) :min 0))
+                 (max (getf (cdr args) :max nil))
+                 (is  (getf (cdr args) :is nil)))
+             (if (and slot-name (symbolp slot-name))
+                 (lambda (obj)
+                   (validate-length-of obj slot-name :min min :max max :is is))
+                 (error "Malformed slot-name: ~A" slot-name))))
+          (:format
+           (let ((slot-name (car args))
+                 (format (cadr args)))
+             (cond ((and slot-name (symbolp slot-name) (stringp format))
+                    (lambda (obj)
+                      (validate-format-of obj slot-name format)))
+                   ((not (stringp format))
+                    (error "~A is not correct format string" format))
+                   (t
+                    (error "Malformed slot-name: ~A" slot-name)))))
+          (:fn
+           (let ((fn (eval (car args))))
+             (cond ((functionp fn)
+                    (lambda (obj)
+                      (funcall fn obj)))
+                   (t (error "~A is not function" fn)))))))
+      (error "Invalid validation entry: ~A" validation-entry)))
+      
+(defun generate-validations-function (validation-list)
+  (loop 
+     for entry in validation-list
+     collect (generate-validation-function entry) into fns
+     finally (return (lambda (obj)
+                       (every (lambda (fn)
+                                (funcall fn obj)) fns)))))
+
+(defgeneric validation-function (class)
+  (:documentation "Generate Validation Function")
+  (:method ((class <dao-table-class>))
+    (if (and (slot-exists-p class 'integral.table::validations)
+             (slot-boundp class 'integral.table::validations))
+        (generate-validations-function (slot-value class 'integral.table::validations))
+        nil)))
+  
+@export
+(defgeneric valid-p (object)
+  (:method ((obj <dao-class>))
+    (let ((validation-fn (validation-function (class-of obj))))
+      (if validation-fn
+          (funcall validation-fn obj)
+          t))))

--- a/t/validation.lisp
+++ b/t/validation.lisp
@@ -1,0 +1,198 @@
+(in-package :cl-user)
+(defpackage integral-test.validation
+  (:use :cl
+        :integral
+        :integral-test.init
+        :prove))
+
+(in-package :integral-test.validation)
+
+(plan nil)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Validation using validation-functions
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(when (find-class 'tweet nil)
+  (setf (find-class 'tweet) nil))
+
+(defclass tweet ()
+  ((id :col-type bigint
+       :auto-increment t
+       :reader tweet-id)
+   (status :col-type (:varchar 140)
+           :initarg :status
+           :accessor :tweet-status)
+   (user :col-type (:varchar 64)
+         :initarg :user
+         :accessor :tweet-user))
+  (:metaclass <dao-table-class>)
+  (:table-name "tweets")
+  (:primary-key (id))
+  (:unique-keys id (status user)))
+
+(connect-to-testdb)
+
+(execute-sql (sxql:drop-table (intern (table-name 'tweet) :keyword) :if-exists t))
+(execute-sql (table-definition 'tweet))
+
+(let ((tweet (make-instance 'tweet
+                            :status "This is the first tweet. Yay."
+                            :user "nitro_idiot")))
+  (ok (insert-dao tweet))
+  (ok (and (slot-boundp tweet 'id)
+           (slot-value tweet 'id)))
+
+  (let ((result (first (select-dao 'tweet))))
+    (is-type result 'tweet)
+    (is (slot-value result 'id)
+        (slot-value tweet 'id))
+    (is (slot-value result 'user)
+        (slot-value tweet 'user))
+    (is (slot-value result 'status)
+        (slot-value tweet 'status))))
+
+(reconnect-to-testdb)
+
+;; Adding the second record.
+(let ((tweet (make-instance 'tweet
+                            :status "Second tweet. Woohoo."
+                            :user "nitro_idiot")))
+  (ok (not (slot-boundp tweet 'id)))
+  (ok (insert-dao tweet)
+      "Can insert")
+  (is (slot-value tweet 'id) 2
+      "The auto increment ID should be incremented"))
+
+(is-type (find-dao 'tweet 1)
+         'tweet)
+
+(reconnect-to-testdb)
+
+(execute-sql (sxql:drop-table (intern (table-name 'tweet) :keyword) :if-exists t))
+(execute-sql (table-definition 'tweet))
+
+;; Add presence validation.
+(defmethod insert-dao :around ((obj tweet))
+  (if (validate-presence-of obj 'status)
+      (call-next-method)
+      (error "Failed to validate-presence-of status")))
+
+(let ((tweet (make-instance 'tweet
+                            :user "nitro_idiot"))
+      (tweet2 (make-instance 'tweet
+                             :status "Fuge"
+                             :user "nitro_idiot")))
+  (is-error (insert-dao tweet) 'simple-error)
+  (ok (insert-dao tweet2))
+  (setf (:tweet-status tweet) "Status yay")
+  (ok (insert-dao tweet) "Can insert now"))
+
+;;Add length validation.
+(reconnect-to-testdb)
+
+(execute-sql (sxql:drop-table (intern (table-name 'tweet) :keyword) :if-exists t))
+(execute-sql (table-definition 'tweet))
+
+(defmethod insert-dao :around ((obj tweet))
+  (if (validate-length-of obj 'status :max 140)
+      (call-next-method)
+      (error "Failed to validate-length-of status")))
+
+
+(let ((tweet (make-instance 'tweet
+                            :status (concatenate 'string "Very l" (make-string 140 :initial-element #\o) "ng")
+                            :user "nitro_idiot"))
+      (tweet2 (make-instance 'tweet
+                             :status "Fuge"
+                             :user "nitro_idiot")))
+  (is-error (insert-dao tweet) 'simple-error)
+  (ok (insert-dao tweet2))
+  (setf (:tweet-status tweet) "Short status.")
+  (ok (insert-dao tweet) "Can insert now with short"))
+
+;;Add validate-formats
+(reconnect-to-testdb)
+
+(execute-sql (sxql:drop-table (intern (table-name 'tweet) :keyword) :if-exists t))
+(execute-sql (table-definition 'tweet))
+
+(defmethod insert-dao :around ((obj tweet))
+  (if (validate-format-of obj 'user "^[A-Za-z0-9_]{1,15}$")
+      (call-next-method)
+      (error "Failed to validate-format-of user")))
+
+(let ((tweet (make-instance 'tweet
+                            :status "First"
+                            :user "@invalid  username")))
+  (is-error (insert-dao tweet) 'simple-error)
+  (setf (:tweet-user tweet) "Hannibal7878")
+  (ok (insert-dao tweet) "Can insert now"))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Validation using class validation slot
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(when (find-class 'secure-account nil)
+  (setf (find-class 'secure-account) nil))
+
+(defvar *validate-fn-results* t)
+
+(defun validate-account (obj)
+  *validate-fn-results*)
+
+(defclass secure-account ()
+  ((id :col-type bigint
+       :auto-increment t
+       :reader tweet-id)
+   (name :col-type (:varchar 100)
+         :initarg :name
+         :accessor :account-name)
+   (password :col-type (:varchar 30)
+             :initarg :pass
+             :accessor :account-pass)
+   (email :col-type (:varchar 64)
+          :initarg :email
+          :accessor :account-email))
+  (:validations
+   (:presence name)
+   (:length password :min 8 :max 30)
+   ;;This is not correct validatin regex but...
+   (:format email "^([a-z0-9\+_\-]+)(\.[a-z0-9\+_\-]+)*@([a-z0-9\-]+\.)+[a-z]{2,6}$")
+   (:fn #'validate-account))
+  (:metaclass <dao-table-class>)
+  (:table-name "accounts")
+  (:primary-key (id))
+  (:unique-keys id))
+
+(connect-to-testdb)
+
+(execute-sql (sxql:drop-table (intern (table-name 'secure-account) :keyword) :if-exists t))
+(execute-sql (table-definition 'secure-account))
+
+(let ((without-name (make-instance 'secure-account
+                                   :pass "test1234"
+                                   :email "poketo7878@gmail.com"))
+      (too-short-pass (make-instance 'secure-account
+                                     :pass "short"
+                                     :email "poketo7878@gmail.com"
+                                     :name "Pocket7878"))
+      (malformed-email (make-instance 'secure-account
+                                      :pass "test1234"
+                                      :email "wrong-email"
+                                      :name "Pocket7878"))
+      (valid-account1 (make-instance 'secure-account
+                                    :name "Pocket7878"
+                                    :pass "test1234"
+                                    :email "poketo7878@gmail.com"))
+      (valid-account2 (make-instance 'secure-account
+                                    :name "Pocket7878"
+                                    :pass "test1234"
+                                    :email "poketo7878@gmail.com")))
+  (ok (not (insert-dao without-name)))
+  (ok (not (insert-dao too-short-pass)))
+  (ok (not (insert-dao malformed-email)))
+  (ok (insert-dao valid-account1))
+  (let ((*validate-fn-results* nil))
+    (ok (not (insert-dao valid-account2)))))
+
+(finalize)


### PR DESCRIPTION
Add "validations" slots to <dao-table-class> with built-in shortcut validation functions.
User can add validation before {insert | update}-dao.
