### PR TITLE
Delay connecting

### DIFF
--- a/integral-test.asd
+++ b/integral-test.asd
@@ -28,6 +28,7 @@
                  (:test-file "connection/sqlite3")
                  (:test-file "connection/mysql")
                  (:test-file "connection/postgres")
+                 (:test-file "connection")
                  (:test-file "type")
                  (:test-file "table")
                  (:test-file "migration/sqlite3")

--- a/t/connection.lisp
+++ b/t/connection.lisp
@@ -19,4 +19,3 @@
   (ok (connection-handle *db*)))
 
 (finalize)
-

--- a/t/connection.lisp
+++ b/t/connection.lisp
@@ -1,0 +1,22 @@
+(in-package :cl-user)
+(defpackage integral-test.connection
+  (:use :cl
+        :integral
+        :integral-test.init
+        :prove)
+  (:import-from :integral.connection
+                :connection-handle))
+(in-package :integral-test.connection)
+
+(plan 2)
+
+(let ((*db* (make-connection :mysql
+                             :database-name "integral_test"
+                             :username "root")))
+  (ok (not (connection-handle *db*)))
+
+  (get-connection)
+  (ok (connection-handle *db*)))
+
+(finalize)
+

--- a/t/init.lisp
+++ b/t/init.lisp
@@ -12,10 +12,12 @@
   (ecase driver-type
     (:sqlite3 (integral-test.init.sqlite3:connect-to-testdb))
     (:mysql (integral-test.init.mysql:connect-to-testdb))
-    (:postgres (integral-test.init.postgres:connect-to-testdb))))
+    (:postgres (integral-test.init.postgres:connect-to-testdb)))
+  (get-connection))
 
 (defun reconnect-to-testdb (&optional (driver-type :sqlite3))
   (ecase driver-type
     (:sqlite3 (integral-test.init.sqlite3:reconnect-to-testdb))
     (:mysql (connect-to-testdb :mysql))
-    (:postgres (connect-to-testdb :postgres))))
+    (:postgres (connect-to-testdb :postgres)))
+  (get-connection))


### PR DESCRIPTION
It changes the behavior of `connect-toplevel` or I can keep this same as before.
If I have to do so, it can not solve the problem of connecting db server in load time with `connect-toplevel`.
