### PR TITLE
slot-name with hyphens in :primary-key doesn't work

### DIFF
--- a/src/table.lisp
+++ b/src/table.lisp
@@ -303,8 +303,8 @@ If you want to use another class, specify it as a superclass in the usual way.")
                             (database-column-slots class))
                            (append
                             (if (slot-boundp class 'primary-key)
-                                (list (apply #'sxql:primary-key
-                                             (slot-value class 'primary-key)))
+                                (list (sxql:primary-key
+                                       (mapcar #'unlispify (car (slot-value class 'primary-key)))))
                                 nil)
                             (if (slot-boundp class 'unique-keys)
                                 (mapcar (lambda (key)

--- a/t/table.lisp
+++ b/t/table.lisp
@@ -149,7 +149,22 @@
            :reader tweet-id))
       (:metaclass <dao-table-class>))
     (is (table-definition 'lispify-name-tweet)
-        "CREATE TABLE `lispify_name_tweet` (`id` INTEGER NOT NULL PRIMARY KEY)")))
+        "CREATE TABLE `lispify_name_tweet` (`id` INTEGER NOT NULL PRIMARY KEY)")
+
+  (defclass tweet ()
+    ((id :type serial
+         :reader tweet-id)
+     (status :type string
+             :accessor :tweet-status)
+     (user-name :type (varchar 64)
+                :accessor :tweet-user-name))
+    (:metaclass <dao-table-class>)
+    (:table-name "tweets")
+    (:unique-keys)
+    (:primary-key (user-name)))
+
+  (is (table-definition 'tweet)
+      "CREATE TABLE `tweets` (`id` INTEGER, `status` TEXT, `user_name` VARCHAR(64), PRIMARY KEY (`user_name`))")))
 
 (subtest ":generate-slots t"
   (dolist (driver '(:sqlite3 :mysql :postgres))


### PR DESCRIPTION
unlispify primary-keys in `table-definition` make #40 works.

(close #40)
